### PR TITLE
Support running commands from discord

### DIFF
--- a/vyxalbot3/commands/dispatcher.py
+++ b/vyxalbot3/commands/dispatcher.py
@@ -56,8 +56,12 @@ class CommandDispatcher:
                             content = await response.text()
                         if not (
                             content.startswith(PREFIX) and len(content) > len(PREFIX)
+                            or
+                            ( bridgeMatch := re.search(r"^\[.*\] "+PREFIX, content) ) and (len(content[bridgeMatch.end():])>0) )
                         ):
                             continue
+                        if bridgeMatch:
+                            content = PREFIX + content[bridgeMatch.end():]
                         try:
                             arguments, explicit_arguments = parse_arguments(content.removeprefix(PREFIX))
                         except ParseError as error:


### PR DESCRIPTION
this has the side effect of treating text in square brackets immediately followed by a command like a comment. i don't think that's really important but here we are.

commands will be ran with bridget's perms. bridget should not have perms.